### PR TITLE
Allow port retry config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Rules access the following parametres:
 - **logFile** - will pipe stdout and stderr to a specified file.
 - **cwd** - rule's working directory
 - **maxGetPortAttempts** - number of attempts to obtain a rule's port. Each attempt waits for 1 second. E.g. set
-`maxGetPortAttempts` to 30 to wait for 30 seconds before a rule is marked as "not available".
+`maxGetPortAttempts` to 30 to wait for 30 seconds before a rule is marked as "not available". Defaults to 10.
 
 ## Cli
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Rules access the following parametres:
 - **env** - the parameter is used to define environment variables for a microservice.
 - **logFile** - will pipe stdout and stderr to a specified file.
 - **cwd** - rule's working directory
+- **maxGetPortAttempts** - number of attempts to obtain a rule's port. Each attempt waits for 1 second. E.g. set
+`maxGetPortAttempts` to 30 to wait for 30 seconds before a rule is marked as "not available".
 
 ## Cli
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,7 @@ const getTree = pid => new Promise((resolve, reject) => {
 const getPortByPid = rule => {
   let attempts = 0;
   const attempt = async () => {
-    if (attempts >= 10) {
+    if (attempts >= rule.maxGetPortAttempts) {
       throw new Error(`Port for rule ${rule.pathname} does not found`);
     }
     try {
@@ -47,7 +47,7 @@ const findRule = ({ rules, host, port, pathname, method }) => {
   const validRules = rules.filter(rule => {
     const rulePathname = rule.pathname.endsWith('/') ? rule.pathname.slice(0, -1) : rule.pathname;
     const requestPathname = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
-    return (host === rule.dest)  || (host === `${rule.dest}:${port}`) || match(rulePathname, requestPathname);
+    return (host === rule.dest) || (host === `${rule.dest}:${port}`) || match(rulePathname, requestPathname);
   });
 
   const findByMethod = validRules.find(rule => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,7 @@ const getTree = pid => new Promise((resolve, reject) => {
 const getPortByPid = rule => {
   let attempts = 0;
   const attempt = async () => {
-    if (attempts >= rule.maxGetPortAttempts) {
+    if (attempts >= rule.maxGetPortAttempts || 10) {
       throw new Error(`Port for rule ${rule.pathname} does not found`);
     }
     try {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,7 @@ const getTree = pid => new Promise((resolve, reject) => {
 const getPortByPid = rule => {
   let attempts = 0;
   const attempt = async () => {
-    if (attempts >= rule.maxGetPortAttempts || 10) {
+    if (attempts >= (rule.maxGetPortAttempts || 10)) {
       throw new Error(`Port for rule ${rule.pathname} does not found`);
     }
     try {


### PR DESCRIPTION
Sometimes, especially when using `dev-gateway` with a Next.js app, it takes time to build and start the app.

Without this PR, `dev-gateway` times out when trying to obtain an app's port. The default of 10 attempts with a 1 second delay each is not enough for a Next.js app.

This PR adds the `maxGetPortAttempts` option. This provides the flexibility to tell `dev-gateway` to wait for more than 10 attempts for certain services.