### PR TITLE
Spawn child process

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const { exec } = require('child_process');
+const { spawn } = require('child_process');
 const { createWriteStream } = require('fs');
 const { createServer } = require('http');
 const { parse } = require('url');
@@ -19,7 +19,8 @@ const run = async (rule, cwd) => {
     cwd = resolve(cwd, rule.cwd);
   }
 
-  const proc = exec(rule.run, {
+  const [command, ...args] = rule.run.split(' ')
+  const proc = spawn(command, args, {
     env: Object.assign(process.env, rule.env || {}),
     cwd: resolve(cwd)
   }, (err) => {

--- a/test/example/app.js
+++ b/test/example/app.js
@@ -16,19 +16,22 @@ module.exports = {
     pathname: '/api/accounts',
     dest: 'accounts.api.localhost',
     method: ['GET', 'POST'],
-    run: 'cd ./accounts && micro index.js -p 3002',
+    run: 'micro index.js -p 3002',
+    cwd: './accounts',
     debug: true
   }, {
     pathname: '/api/entries/*',
     method: 'GET',
     dest: 'entries.api.localhost',
-    run: 'cd ./entries && micro index.js -p 3003',
+    run: 'micro index.js -p 3003',
+    cwd: './entries',
     debug: true
   }, {
     pathname: '/api/entries/*',
     method: 'POST',
     dest: 'entries.api.localhost',
-    run: 'cd ./add-entry && micro index.js -p 3004',
+    run: 'micro index.js -p 3004',
+    cwd: './add-entry',
     debug: true
   }, {
     pathname: '/proxy',


### PR DESCRIPTION
Use spawn child process instead of exec, to avoid buffering the complete command's generated output. The maximum buffer size could be reached very fast.
